### PR TITLE
Fixes for Jenkins configuration. With this change the command “az pro…

### DIFF
--- a/src/command_modules/azure-cli-project/azure/cli/command_modules/project/custom.py
+++ b/src/command_modules/azure-cli-project/azure/cli/command_modules/project/custom.py
@@ -41,7 +41,6 @@ def create_continuous_deployment(remote_access_token): # pylint: disable=unused-
     # Wait for deployments to complete
     spinnaker_deployment.wait()
     jenkins_deployment.wait()
-    _ = jenkins_deployment.result()
     jenkins_resource.configure()
 
     spinnaker_deployment_result = spinnaker_deployment.result()
@@ -65,9 +64,10 @@ def _configure_spinnaker(spinnaker_resource, spinnaker_hostname):
     cluster_resource_group = project_settings.cluster_resource_group
     container_registry_url = project_settings.container_registry_url
 
+    repo_name = '{}/{}'.format(project_settings.admin_username, 'myfirstapp')
     acs_info = _get_acs_info(cluster_name, cluster_resource_group)
     spinnaker_resource.configure(
-        spinnaker_hostname, acs_info, container_registry_url, 'myrepo/peterj', client_id, client_secret)
+        spinnaker_hostname, acs_info, container_registry_url, repo_name, client_id, client_secret)
 
 def _deploy_jenkins():
     """


### PR DESCRIPTION
…ject continuous-deployment create --remote-access-token” works - it will setup Jenkins and Spinnaker instance. The prerequisite is a file ```~/.azure/projectResource.json``` that contains the  settings (this file will be populated by the initial create/setup command). The following info is needed in the file:
```
{
  "client_id": “SERVICEPRINCIPAL_ID”,
  "client_secret": “SERVICE_PRINCIPAL_SECRET”,
  "resource_group": “RESOURCE_GROUP_WHERE_TO_DEPLOY”,
  "cluster_name": “EXISTING_KUBE_CLUSTER_NAME”,
  "cluster_resource_group": “EXISTING_KUBE_CLUSTER_RESOURCE_GROUP”,
  "admin_username": "azureuser",
  "container_registry_url": “CONTAINER_REGISTRY_URL”
}
```