### PR TITLE
Add support for generic reference (i.e. ‘azp reference add —env-varia…

### DIFF
--- a/src/command_modules/azure-cli-project/azure/cli/command_modules/project/_params.py
+++ b/src/command_modules/azure-cli-project/azure/cli/command_modules/project/_params.py
@@ -50,6 +50,22 @@ name_arg_type = CliArgumentType(
 reference_name = CliArgumentType(
     options_list=('--reference-name', '-r'))
 
+environment_variables = CliArgumentType(
+    options_list=('--env-variables', '-e'),
+    help="Space separated 'name=value' pairs",
+    required=False)
+
+optional_target_group = CliArgumentType(
+    options_list=('--target-group', '-g'),
+    help="Target resoure group name",
+    required=False
+)
+
+optional_target_name = CliArgumentType(
+    options_list=('--target-name', '-n'),
+    required=False
+)
+
 register_cli_argument('project', 'remote_access_token', remote_access_token)
 register_cli_argument('project', 'project_path', project_path)
 register_cli_argument('project', 'ssh_private_key', ssh_private_key)
@@ -60,8 +76,10 @@ register_cli_argument('project', 'location', location_type)
 register_cli_argument('project', 'force_create',
                       force_create, action='store_true')
 register_cli_argument('project', 'wait', wait, action='store_true')
+register_cli_argument('project', 'env_variables',
+                      environment_variables, nargs='+')
 
-
-register_cli_argument('project', 'target-group', resource_group_name_type)
-register_cli_argument('project', 'target-name', name_arg_type)
+register_cli_argument('project', 'target_group',
+                      optional_target_group)
+register_cli_argument('project', 'target_name', optional_target_name)
 register_cli_argument('project', 'reference-name', reference_name)

--- a/src/command_modules/azure-cli-project/azure/cli/command_modules/project/references.py
+++ b/src/command_modules/azure-cli-project/azure/cli/command_modules/project/references.py
@@ -3,15 +3,19 @@ import azure.cli.command_modules.project.settings as settings
 import azure.cli.command_modules.project.utils as utils
 from azure.cli.command_modules.documentdb._client_factory import cf_documentdb
 from azure.cli.core._util import CLIError
+from azure.cli.core.prompting import prompt, prompt_pass
 
 
-def _create_environment_var_name(reference_name, suffix):
+def _create_environment_var_name(reference_name, suffix=None):
     """
     Creates the environment variable name using
     the reference name and suffix.
     """
     reference_name = reference_name.replace('-', '_')
-    return '{}_{}'.format(reference_name, suffix).upper()
+    if suffix:
+        return '{}_{}'.format(reference_name, suffix).upper()
+    else:
+        return reference_name.upper()
 
 
 def get_secret_name(service_name, reference_name):
@@ -50,54 +54,126 @@ def reference_exists(service_name, reference_name):
     return exit_code == 0
 
 
+def _get_dictionary(input_string):
+    """
+    Parses the input string (e.g. VAR1=VALUE1 VAR2=VALUE2 ...)
+    and returns the dictionary of key/value pairs
+    """
+    return_dict = {}
+    for entry in input_string:
+        parts = entry.split('=', 1)
+        if len(parts) == 1:
+            raise CLIError(
+                'usage error: --env-variables KEY=VALUE KEY=VALUE ...')
+        return_dict[parts[0]] = parts[1]
+    return return_dict
+
+
+def add_reference(service_name, target_group, target_name, reference_name, env_variables):
+    """
+    Adds a references to an Azure resource
+    """
+    instance_type = None
+    created_variables = []
+
+    # If target_group and target_name are not set
+    # it means we are dealing with a generic reference
+    if not target_group and not target_name:
+        instance_type = 'Generic'
+        if not env_variables:
+            raise CLIError('Environment variables were not provided')
+        dict_vars = _get_dictionary(env_variables)
+        created_variables = _create_custom_reference(
+            service_name, reference_name, dict_vars)
+    else:
+        instance, client = get_reference_type(target_group, target_name)
+        instance_type = instance.type
+        if instance_type == 'Microsoft.DocumentDB/databaseAccounts':
+            results = client.list_connection_strings(
+                target_group, target_name)
+            if len(results.connection_strings) <= 0:
+                raise CLIError('No connection strings found')
+            connection_string = results.connection_strings[0].connection_string
+            created_variables = create_connection_string_reference(
+                service_name, reference_name, connection_string)
+        elif instance_type == 'Microsoft.Sql/servers':
+            sql_admin_login = instance.administrator_login
+            if not sql_admin_login:
+                sql_admin_login = prompt('Administrator login:')
+            sql_admin_password = instance.administrator_login_password
+            if not sql_admin_password:
+                sql_admin_password = prompt_pass('Password:')
+            fqdn = instance.fully_qualified_domain_name
+            created_variables = create_username_password_reference(
+                service_name, reference_name, sql_admin_login, sql_admin_password, fqdn)
+        elif instance_type == 'Microsoft.ServiceBus':
+            connection_string = instance.list_keys(
+                target_group, target_name, 'RootManageSharedAccessKey').primary_connection_string
+            created_variables = create_connection_string_reference(
+                service_name, reference_name, connection_string)
+        else:
+            raise CLIError('Could not determine the reference type')
+
+    project_settings = settings.Project()
+    project_settings.add_reference(service_name, reference_name, instance_type)
+    return created_variables, instance_type
+
+
+def _create_custom_reference(service_name, reference_name, key_value_pairs):
+    """
+    Creates a custom reference, stores the key value pairs
+    in the Kubernetes secret, labels the secret with service name
+    and returns the array of environment variable names that were added
+    """
+    secret_name = get_secret_name(service_name, reference_name)
+
+    env_variables = []
+    literals = []
+    for key, value in key_value_pairs.items():
+        env_variables.append(key)
+        literals.append('--from-literal={}={}'.format(key, value))
+
+    command = 'kubectl create secret generic {} {}'.format(
+        secret_name, ' '.join(literals))
+    utils.execute_command(command)
+    _add_run_label(secret_name, service_name)
+
+    return env_variables
+
+
 def create_connection_string_reference(service_name, reference_name, connection_string):
     """
     Creates a secret on Kubernetes that stores
     the connection string and is labeled with run=service_name
     Returns the list of environment variable names
     """
-    secret_name = get_secret_name(service_name, reference_name)
     environment_variable_name = _create_environment_var_name(
         reference_name, 'connection_string')
 
-    # Create the secret
-    command = 'kubectl create secret generic {} --from-literal={}={}'.format(
-        secret_name, environment_variable_name, connection_string)
-    utils.execute_command(command)
+    pairs = {environment_variable_name: connection_string}
+    _create_custom_reference(service_name, reference_name, pairs)
 
-    # Label it with run=service_name
-    _add_run_label(secret_name, service_name)
     return [environment_variable_name]
 
 
-def create_sqlserver_reference(service_name, reference_name, admin_login, admin_password, fqdn):
+def create_username_password_reference(service_name, reference_name, admin_login, admin_password, fqdn):
     """
-    Creates a secret on Kubernetes for SQL server that stores
+    Creates a secret on Kubernetes that stores
     the administrator login, password and fully qualified domain name
     Returns the list of environment variable names
     """
-    secret_name = get_secret_name(service_name, reference_name)
-
     admin_login_var = _create_environment_var_name(
         reference_name, 'admin_login')
     admin_password_var = _create_environment_var_name(
         reference_name, 'admin_password')
     fqdn_var = _create_environment_var_name(reference_name, 'fqdn')
 
-    command = 'kubectl create secret generic {}\
-               --from-literal={}={}\
-               --from-literal={}={}\
-               --from-literal={}={}'.format(secret_name,
-                                            admin_login_var, admin_login,
-                                            admin_password_var, admin_password,
-                                            fqdn_var, fqdn)
-    utils.execute_command(command)
+    pairs = {admin_login_var: admin_login,
+             admin_password_var: admin_password, fqdn_var: fqdn}
+    environment_variables = _create_custom_reference(
+        service_name, reference_name, pairs)
 
-    # Label it with run=service_name
-    _add_run_label(secret_name, 'run={}'.format(service_name))
-    return [admin_login_var,
-            admin_password_var,
-            fqdn_var]
+    return environment_variables
 
 
 def remove_reference(service_name, reference_name):


### PR DESCRIPTION
…bles VAR1=blah VAR2=blah’). It also makes the target-group and target-name arguments optional, so if they are not provided, we are using the generic reference type. If target-group or name are provided we will try to figure out the reference type. If you also provide the environment variables, we are going to ignore them.